### PR TITLE
change package name:

### DIFF
--- a/render/rendering.go
+++ b/render/rendering.go
@@ -1,4 +1,4 @@
-package internal
+package render
 
 import (
 	"fmt"

--- a/render/rendering_test.go
+++ b/render/rendering_test.go
@@ -1,4 +1,4 @@
-package internal
+package render
 
 import (
 	"os"


### PR DESCRIPTION
interval -> render

in golang we can't call a package named 'internal'.
'imports github.com/sbwhitecap/tqdm/internal: use of internal package not allowed'